### PR TITLE
CMS110 store junit report in dedicated dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ jobs:
             pip install -q -r requirements_dead_links.txt
             TEST_ENV=DEV make dead_links_check
       - store_test_results:
-          path: ./report.xml
+          path: ./reports
       - store_artifacts:
-          path: ./report.xml
+          path: ./reports
 
   check_for_dead_links_on_stage:
     docker:
@@ -48,9 +48,9 @@ jobs:
             pip install -q -r requirements_dead_links.txt
             TEST_ENV=STAGE make dead_links_check
       - store_test_results:
-          path: ./report.xml
+          path: ./reports
       - store_artifacts:
-          path: ./report.xml
+          path: ./reports
 
   check_for_dead_links_on_prod:
     docker:
@@ -66,9 +66,9 @@ jobs:
             pip install -q -r requirements_dead_links.txt
             TEST_ENV=PROD make dead_links_check
       - store_test_results:
-          path: ./report.xml
+          path: ./reports
       - store_artifacts:
-          path: ./report.xml
+          path: ./reports
 
 workflows:
   version: 2

--- a/makefile
+++ b/makefile
@@ -25,7 +25,7 @@ dead_links_check:
 	    --test-outside \
 	    --parser=lxml \
 	    --format=junit \
-	    --output=report.xml \
+	    --output=./reports/dead_links_report.xml \
 	    --header="Connection: keep-alive" \
 	    --header="Pragma: no-cache" \
 	    --header="Cache-Control: no-cache" \

--- a/reports/.gitignore
+++ b/reports/.gitignore
@@ -1,0 +1,6 @@
+
+# Ignore everything
+*
+
+# But not these files...
+!.gitignore


### PR DESCRIPTION
This should make CircleCI pick up the report file after each test run and parse it.
Here's the documentation https://circleci.com/docs/2.0/configuration-reference/#store_test_results